### PR TITLE
Fix black mesa multi blend lump reading

### DIFF
--- a/src/main/java/info/ata4/bsplib/BspFileReader.java
+++ b/src/main/java/info/ata4/bsplib/BspFileReader.java
@@ -530,7 +530,15 @@ public class BspFileReader {
             return;
         }
 
-        bspData.dispmultiblend = loadLump(LumpType.LUMP_DISP_MULTIBLEND, DDispMultiBlend.class);
+        // black mesa uses the LUMP_OVERLAY_SYSTEM_LEVELS lump to store multiblend information.
+        // the original purpose of that lump is no longer used
+        LumpType lumpType;
+        if (appID == BLACK_MESA)
+            lumpType = LumpType.LUMP_OVERLAY_SYSTEM_LEVELS;
+        else
+            lumpType = LumpType.LUMP_DISP_MULTIBLEND;
+
+        bspData.dispmultiblend = loadLump(lumpType, DDispMultiBlend.class);
     }
 
     public void loadTexInfo() {
@@ -717,7 +725,11 @@ public class BspFileReader {
 
         // read CPU/GPU levels
         if (bspData.overlaySysLevels == null) {
-            bspData.overlaySysLevels = loadLump(LumpType.LUMP_OVERLAY_SYSTEM_LEVELS, DOverlaySystemLevel.class);
+            // black mesa uses this lump for displacement multiblend
+            if (appID == BLACK_MESA)
+                bspData.overlaySysLevels = Collections.emptyList();
+            else
+                bspData.overlaySysLevels = loadLump(LumpType.LUMP_OVERLAY_SYSTEM_LEVELS, DOverlaySystemLevel.class);
         }
     }
 


### PR DESCRIPTION
The LUMP_DISP_MULTIBLEND lump is used to save multiblend information
for 4-way displacements. Black mesa saves this lump at a
different index however, causing displacements to not be properly
decompiled. Normally, the lump is at index 63, while in this game its
located at 61. The original lump located at 61 doesn't seem to be used
by the game anymore.